### PR TITLE
feat: add API layers for CarModels and ExtraFeatures

### DIFF
--- a/src/main/java/no/ntnu/controller/CarModelsController.java
+++ b/src/main/java/no/ntnu/controller/CarModelsController.java
@@ -1,0 +1,135 @@
+package no.ntnu.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import no.ntnu.dto.carmodels.CarModelsRequest;
+import no.ntnu.dto.carmodels.CarModelsResponse;
+import no.ntnu.service.CarModelsService;
+
+/**
+ * REST controller for managing car models.
+ */
+@RestController
+@Validated
+@Tag(name = "Car Models", description = "Endpoints for managing car models")
+@RequestMapping("/api/car-models")
+public class CarModelsController {
+
+  private final CarModelsService carModelsService;
+
+  public CarModelsController(CarModelsService carModelsService) {
+    this.carModelsService = carModelsService;
+  }
+
+  /**
+   * Retrieves all car models.
+   *
+   * @return a list of all car models
+   */
+  @GetMapping
+  @Operation(summary = "Get all car models")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Car models retrieved")
+  })
+  public ResponseEntity<List<CarModelsResponse>> getAll() {
+    return ResponseEntity.ok(carModelsService.getAll());
+  }
+
+  /**
+   * Retrieves a car model by its ID.
+   *
+   * @param id the ID of the car model
+   * @return the car model
+   */
+  @GetMapping("/{id}")
+  @Operation(summary = "Get a car model by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Car model found"),
+      @ApiResponse(responseCode = "404", description = "Car model not found")
+  })
+  public ResponseEntity<CarModelsResponse> getById(
+      @Parameter(description = "ID of the car model", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    return ResponseEntity.ok(carModelsService.getById(id));
+  }
+
+  /**
+   * Creates a new car model.
+   *
+   * @param request the car model data
+   * @return the created car model
+   */
+  @PostMapping
+  @Operation(summary = "Create a new car model")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "Car model created"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data")
+  })
+  public ResponseEntity<CarModelsResponse> create(
+      @Valid @RequestBody CarModelsRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(carModelsService.create(request));
+  }
+
+  /**
+   * Updates an existing car model.
+   *
+   * @param id      the ID of the car model to update
+   * @param request the updated car model data
+   * @return the updated car model
+   */
+  @PutMapping("/{id}")
+  @Operation(summary = "Update a car model by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Car model updated"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data"),
+      @ApiResponse(responseCode = "404", description = "Car model not found")
+  })
+  public ResponseEntity<CarModelsResponse> update(
+      @Parameter(description = "ID of the car model", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id,
+      @Valid @RequestBody CarModelsRequest request) {
+    return ResponseEntity.ok(carModelsService.update(id, request));
+  }
+
+  /**
+   * Deletes a car model by its ID.
+   *
+   * @param id the ID of the car model to delete
+   * @return 204 No Content on success
+   */
+  @DeleteMapping("/{id}")
+  @Operation(summary = "Delete a car model by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Car model deleted"),
+      @ApiResponse(responseCode = "404", description = "Car model not found")
+  })
+  public ResponseEntity<Void> deleteById(
+      @Parameter(description = "ID of the car model", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    carModelsService.deleteById(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/no/ntnu/controller/ExtraFeaturesController.java
+++ b/src/main/java/no/ntnu/controller/ExtraFeaturesController.java
@@ -1,0 +1,135 @@
+package no.ntnu.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import no.ntnu.dto.extrafeatures.ExtraFeaturesRequest;
+import no.ntnu.dto.extrafeatures.ExtraFeaturesResponse;
+import no.ntnu.service.ExtraFeaturesService;
+
+/**
+ * REST controller for managing extra features.
+ */
+@RestController
+@Validated
+@Tag(name = "Extra Features", description = "Endpoints for managing extra features")
+@RequestMapping("/api/extra-features")
+public class ExtraFeaturesController {
+
+  private final ExtraFeaturesService extraFeaturesService;
+
+  public ExtraFeaturesController(ExtraFeaturesService extraFeaturesService) {
+    this.extraFeaturesService = extraFeaturesService;
+  }
+
+  /**
+   * Retrieves all extra features.
+   *
+   * @return a list of all extra features
+   */
+  @GetMapping
+  @Operation(summary = "Get all extra features")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Extra features retrieved")
+  })
+  public ResponseEntity<List<ExtraFeaturesResponse>> getAll() {
+    return ResponseEntity.ok(extraFeaturesService.getAll());
+  }
+
+  /**
+   * Retrieves an extra feature by its ID.
+   *
+   * @param id the ID of the extra feature
+   * @return the extra feature
+   */
+  @GetMapping("/{id}")
+  @Operation(summary = "Get an extra feature by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Extra feature found"),
+      @ApiResponse(responseCode = "404", description = "Extra feature not found")
+  })
+  public ResponseEntity<ExtraFeaturesResponse> getById(
+      @Parameter(description = "ID of the extra feature", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    return ResponseEntity.ok(extraFeaturesService.getById(id));
+  }
+
+  /**
+   * Creates a new extra feature.
+   *
+   * @param request the extra feature data
+   * @return the created extra feature
+   */
+  @PostMapping
+  @Operation(summary = "Create a new extra feature")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "Extra feature created"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data")
+  })
+  public ResponseEntity<ExtraFeaturesResponse> create(
+      @Valid @RequestBody ExtraFeaturesRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(extraFeaturesService.create(request));
+  }
+
+  /**
+   * Updates an existing extra feature.
+   *
+   * @param id      the ID of the extra feature to update
+   * @param request the updated extra feature data
+   * @return the updated extra feature
+   */
+  @PutMapping("/{id}")
+  @Operation(summary = "Update an extra feature by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Extra feature updated"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data"),
+      @ApiResponse(responseCode = "404", description = "Extra feature not found")
+  })
+  public ResponseEntity<ExtraFeaturesResponse> update(
+      @Parameter(description = "ID of the extra feature", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id,
+      @Valid @RequestBody ExtraFeaturesRequest request) {
+    return ResponseEntity.ok(extraFeaturesService.update(id, request));
+  }
+
+  /**
+   * Deletes an extra feature by its ID.
+   *
+   * @param id the ID of the extra feature to delete
+   * @return 204 No Content on success
+   */
+  @DeleteMapping("/{id}")
+  @Operation(summary = "Delete an extra feature by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Extra feature deleted"),
+      @ApiResponse(responseCode = "404", description = "Extra feature not found")
+  })
+  public ResponseEntity<Void> deleteById(
+      @Parameter(description = "ID of the extra feature", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    extraFeaturesService.deleteById(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/no/ntnu/dto/carmodels/CarModelsRequest.java
+++ b/src/main/java/no/ntnu/dto/carmodels/CarModelsRequest.java
@@ -1,0 +1,70 @@
+package no.ntnu.dto.carmodels;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import no.ntnu.entity.CarModels;
+
+/**
+ * DTO for creating or updating a {@link no.ntnu.entity.CarModels car model}.
+ */
+@Schema(description = "Request body for creating or updating a car model")
+public record CarModelsRequest(
+
+    @NotBlank(message = "Brand is required")
+    @Size(max = 64, message = "Brand must be at most 64 characters")
+    @Schema(description = "The brand of the car", example = "BMW")
+    String brand,
+
+    @NotBlank(message = "Model name is required")
+    @Size(max = 64, message = "Model name must be at most 64 characters")
+    @Schema(description = "The model name of the car", example = "i4 eDrive40")
+    String modelName,
+
+    @NotNull(message = "Car type is required")
+    @Schema(description = "The type of the car", example = "SEDAN")
+    CarModels.CarType carType,
+
+    @Min(value = 1886, message = "Production year must be 1886 or later")
+    @Schema(description = "The production year of the car", example = "2024")
+    int productionYear,
+
+    @Min(value = 1, message = "Passengers must be at least 1")
+    @Schema(description = "The number of passengers the car can carry", example = "5")
+    int passengers,
+
+    @NotNull(message = "Transmission is required")
+    @Schema(description = "The transmission type of the car", example = "AUTOMATIC")
+    CarModels.Transmission transmission,
+
+    @NotNull(message = "Energy source is required")
+    @Schema(description = "The energy source of the car", example = "ELECTRIC")
+    CarModels.EnergySource energySource,
+
+    @Schema(description = "The engine specification of the car", example = "2.0L Turbo")
+    String engine,
+
+    @Schema(description = "Battery capacity in kWh", example = "83.9")
+    BigDecimal batteryCapacityKwh,
+
+    @Schema(description = "Range in kilometers", example = "590")
+    Integer rangeKm,
+
+    @Schema(description = "The range measurement standard", example = "WLTP")
+    CarModels.RangeStandard rangeStandard,
+
+    @Schema(description = "Top speed in km/h", example = "190")
+    Integer topSpeedKmh,
+
+    @Schema(description = "Acceleration from 0-100 km/h in seconds", example = "5.6")
+    BigDecimal acceleration,
+
+    @Schema(description = "IDs of extra features to associate with this car model", example = "[1, 2, 3]")
+    Set<Long> extraFeatureIds
+
+) {}

--- a/src/main/java/no/ntnu/dto/carmodels/CarModelsResponse.java
+++ b/src/main/java/no/ntnu/dto/carmodels/CarModelsResponse.java
@@ -1,0 +1,61 @@
+package no.ntnu.dto.carmodels;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import no.ntnu.dto.extrafeatures.ExtraFeaturesResponse;
+import no.ntnu.entity.CarModels;
+
+/**
+ * DTO for returning a {@link no.ntnu.entity.CarModels car model} in API responses.
+ */
+@Schema(description = "Response body representing a car model")
+public record CarModelsResponse(
+
+    @Schema(description = "The ID of the car model", example = "1")
+    Long id,
+
+    @Schema(description = "The brand of the car", example = "BMW")
+    String brand,
+
+    @Schema(description = "The model name of the car", example = "i4 eDrive40")
+    String modelName,
+
+    @Schema(description = "The type of the car", example = "SEDAN")
+    CarModels.CarType carType,
+
+    @Schema(description = "The production year of the car", example = "2024")
+    int productionYear,
+
+    @Schema(description = "The number of passengers the car can carry", example = "5")
+    int passengers,
+
+    @Schema(description = "The transmission type of the car", example = "AUTOMATIC")
+    CarModels.Transmission transmission,
+
+    @Schema(description = "The energy source of the car", example = "ELECTRIC")
+    CarModels.EnergySource energySource,
+
+    @Schema(description = "The engine specification of the car", example = "2.0L Turbo")
+    String engine,
+
+    @Schema(description = "Battery capacity in kWh", example = "83.9")
+    BigDecimal batteryCapacityKwh,
+
+    @Schema(description = "Range in kilometers", example = "590")
+    Integer rangeKm,
+
+    @Schema(description = "The range measurement standard", example = "WLTP")
+    CarModels.RangeStandard rangeStandard,
+
+    @Schema(description = "Top speed in km/h", example = "190")
+    Integer topSpeedKmh,
+
+    @Schema(description = "Acceleration from 0-100 km/h in seconds", example = "5.6")
+    BigDecimal acceleration,
+
+    @Schema(description = "The extra features of the car model")
+    List<ExtraFeaturesResponse> extraFeatures
+
+) {}

--- a/src/main/java/no/ntnu/dto/extrafeatures/ExtraFeaturesRequest.java
+++ b/src/main/java/no/ntnu/dto/extrafeatures/ExtraFeaturesRequest.java
@@ -1,0 +1,22 @@
+package no.ntnu.dto.extrafeatures;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO for creating or updating an {@link no.ntnu.entity.ExtraFeatures extra feature}.
+ */
+@Schema(description = "Request body for creating or updating an extra feature")
+public record ExtraFeaturesRequest(
+
+    @NotBlank(message = "Name is required")
+    @Size(max = 32, message = "Name must be at most 32 characters")
+    @Schema(description = "The name of the extra feature", example = "Heated Seats")
+    String name,
+
+    @Size(max = 255, message = "Description must be at most 255 characters")
+    @Schema(description = "A description of the extra feature", example = "Front and rear heated seats with three levels")
+    String description
+
+) {}

--- a/src/main/java/no/ntnu/dto/extrafeatures/ExtraFeaturesResponse.java
+++ b/src/main/java/no/ntnu/dto/extrafeatures/ExtraFeaturesResponse.java
@@ -1,0 +1,20 @@
+package no.ntnu.dto.extrafeatures;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO for returning an {@link no.ntnu.entity.ExtraFeatures extra feature} in API responses.
+ */
+@Schema(description = "Response body representing an extra feature")
+public record ExtraFeaturesResponse(
+
+    @Schema(description = "The ID of the extra feature", example = "1")
+    Long id,
+
+    @Schema(description = "The name of the extra feature", example = "Heated Seats")
+    String name,
+
+    @Schema(description = "A description of the extra feature", example = "Front and rear heated seats with three levels")
+    String description
+
+) {}

--- a/src/main/java/no/ntnu/exception/GlobalExceptionHandler.java
+++ b/src/main/java/no/ntnu/exception/GlobalExceptionHandler.java
@@ -50,7 +50,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(NotFoundException.class)
   public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex) {
-    logger.error("Resource not found: ", ex);
+    logger.error("{}", ex.getMessage());
     return buildResponse(HttpStatus.NOT_FOUND, ex.getMessage());
   }
 

--- a/src/main/java/no/ntnu/service/CarModelsService.java
+++ b/src/main/java/no/ntnu/service/CarModelsService.java
@@ -1,0 +1,170 @@
+package no.ntnu.service;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import no.ntnu.dto.carmodels.CarModelsRequest;
+import no.ntnu.dto.carmodels.CarModelsResponse;
+import no.ntnu.dto.extrafeatures.ExtraFeaturesResponse;
+import no.ntnu.entity.CarModels;
+import no.ntnu.entity.ExtraFeatures;
+import no.ntnu.exception.NotFoundException;
+import no.ntnu.repository.CarModelsRepository;
+import no.ntnu.repository.ExtraFeaturesRepository;
+
+/**
+ * Service for managing {@link CarModels} entities.
+ */
+@Service
+public class CarModelsService {
+  private static final Logger logger = LoggerFactory.getLogger(CarModelsService.class);
+
+  private final CarModelsRepository carModelsRepository;
+  private final ExtraFeaturesRepository extraFeaturesRepository;
+
+  public CarModelsService(CarModelsRepository carModelsRepository,
+      ExtraFeaturesRepository extraFeaturesRepository) {
+    this.carModelsRepository = carModelsRepository;
+    this.extraFeaturesRepository = extraFeaturesRepository;
+  }
+
+  /**
+   * Retrieves all car models.
+   *
+   * @return a list of all car models
+   */
+  public List<CarModelsResponse> getAll() {
+    logger.debug("Retrieving all car models");
+    return carModelsRepository.findAll().stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Retrieves a car model by its ID.
+   *
+   * @param id the ID of the car model
+   * @return the car model
+   * @throws NotFoundException if no car model with the given ID exists
+   */
+  public CarModelsResponse getById(Long id) {
+    logger.debug("Retrieving car model with ID: {}", id);
+    return carModelsRepository.findById(id)
+        .map(this::toResponse)
+        .orElseThrow(() -> new NotFoundException(
+            "Car model with ID " + id + " not found"));
+  }
+
+  /**
+   * Creates a new car model.
+   *
+   * @param request the car model data
+   * @return the created car model
+   */
+  public CarModelsResponse create(CarModelsRequest request) {
+    logger.info("Creating car model: {} {}", request.brand(), request.modelName());
+    CarModels entity = new CarModels();
+    applyRequest(entity, request);
+    CarModels saved = carModelsRepository.save(entity);
+    logger.info("Created car model with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Updates an existing car model.
+   *
+   * @param id      the ID of the car model to update
+   * @param request the updated car model data
+   * @return the updated car model
+   * @throws NotFoundException if no car model with the given ID exists
+   */
+  public CarModelsResponse update(Long id, CarModelsRequest request) {
+    logger.info("Updating car model with ID: {}", id);
+    CarModels existing = carModelsRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "Car model with ID " + id + " not found"));
+    applyRequest(existing, request);
+    CarModels saved = carModelsRepository.save(existing);
+    logger.info("Updated car model with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Deletes a car model by its ID.
+   *
+   * @param id the ID of the car model to delete
+   * @throws NotFoundException if no car model with the given ID exists
+   */
+  public void deleteById(Long id) {
+    logger.info("Deleting car model with ID: {}", id);
+    if (!carModelsRepository.existsById(id)) {
+      throw new NotFoundException("Car model with ID " + id + " not found");
+    }
+    carModelsRepository.deleteById(id);
+    logger.info("Deleted car model with ID: {}", id);
+  }
+
+  /**
+   * Applies the fields from a request DTO to a car model entity.
+   *
+   * @param entity  the entity to update
+   * @param request the request data
+   */
+  private void applyRequest(CarModels entity, CarModelsRequest request) {
+    entity.setBrand(request.brand());
+    entity.setModelName(request.modelName());
+    entity.setCarType(request.carType());
+    entity.setProductionYear(request.productionYear());
+    entity.setPassengers(request.passengers());
+    entity.setTransmission(request.transmission());
+    entity.setEnergySource(request.energySource());
+    entity.setEngine(request.engine());
+    entity.setBatteryCapacityKwh(request.batteryCapacityKwh());
+    entity.setRangeKm(request.rangeKm());
+    entity.setRangeStandard(request.rangeStandard());
+    entity.setTopSpeedKmh(request.topSpeedKmh());
+    entity.setAcceleration(request.acceleration());
+
+    if (request.extraFeatureIds() != null && !request.extraFeatureIds().isEmpty()) {
+      entity.setExtraFeatures(
+          new HashSet<>(extraFeaturesRepository.findAllById(request.extraFeatureIds())));
+    } else {
+      entity.setExtraFeatures(null);
+    }
+  }
+
+  /**
+   * Converts a {@link CarModels} entity to a {@link CarModelsResponse} DTO.
+   *
+   * @param entity the entity to convert
+   * @return the response DTO
+   */
+  private CarModelsResponse toResponse(CarModels entity) {
+    List<ExtraFeaturesResponse> extraFeatures = entity.getExtraFeatures() == null
+        ? List.of()
+        : entity.getExtraFeatures().stream()
+            .map(ef -> new ExtraFeaturesResponse(ef.getId(), ef.getName(), ef.getDescription()))
+            .toList();
+
+    return new CarModelsResponse(
+        entity.getId(),
+        entity.getBrand(),
+        entity.getModelName(),
+        entity.getCarType(),
+        entity.getProductionYear(),
+        entity.getPassengers(),
+        entity.getTransmission(),
+        entity.getEnergySource(),
+        entity.getEngine(),
+        entity.getBatteryCapacityKwh(),
+        entity.getRangeKm(),
+        entity.getRangeStandard(),
+        entity.getTopSpeedKmh(),
+        entity.getAcceleration(),
+        extraFeatures);
+  }
+}

--- a/src/main/java/no/ntnu/service/ExtraFeaturesService.java
+++ b/src/main/java/no/ntnu/service/ExtraFeaturesService.java
@@ -61,8 +61,7 @@ public class ExtraFeaturesService {
   public ExtraFeaturesResponse create(ExtraFeaturesRequest request) {
     logger.info("Creating extra feature with name: {}", request.name());
     ExtraFeatures entity = new ExtraFeatures();
-    entity.setName(request.name());
-    entity.setDescription(request.description());
+    applyRequest(entity, request);
     ExtraFeatures saved = extraFeaturesRepository.save(entity);
     logger.info("Created extra feature with ID: {}", saved.getId());
     return toResponse(saved);
@@ -81,8 +80,7 @@ public class ExtraFeaturesService {
     ExtraFeatures existing = extraFeaturesRepository.findById(id)
         .orElseThrow(() -> new NotFoundException(
             "Extra feature with ID " + id + " not found"));
-    existing.setName(request.name());
-    existing.setDescription(request.description());
+    applyRequest(existing, request);
     ExtraFeatures saved = extraFeaturesRepository.save(existing);
     logger.info("Updated extra feature with ID: {}", saved.getId());
     return toResponse(saved);
@@ -102,6 +100,17 @@ public class ExtraFeaturesService {
     }
     extraFeaturesRepository.deleteById(id);
     logger.info("Deleted extra feature with ID: {}", id);
+  }
+
+  /**
+   * Applies the fields from a request DTO to an extra features entity.
+   *
+   * @param entity  the entity to update
+   * @param request the request data
+   */
+  private void applyRequest(ExtraFeatures entity, ExtraFeaturesRequest request) {
+    entity.setName(request.name());
+    entity.setDescription(request.description());
   }
 
   /**

--- a/src/main/java/no/ntnu/service/ExtraFeaturesService.java
+++ b/src/main/java/no/ntnu/service/ExtraFeaturesService.java
@@ -1,0 +1,116 @@
+package no.ntnu.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import no.ntnu.dto.extrafeatures.ExtraFeaturesRequest;
+import no.ntnu.dto.extrafeatures.ExtraFeaturesResponse;
+import no.ntnu.entity.ExtraFeatures;
+import no.ntnu.exception.NotFoundException;
+import no.ntnu.repository.ExtraFeaturesRepository;
+
+/**
+ * Service for managing {@link ExtraFeatures} entities.
+ */
+@Service
+public class ExtraFeaturesService {
+  private static final Logger logger = LoggerFactory.getLogger(ExtraFeaturesService.class);
+
+  private final ExtraFeaturesRepository extraFeaturesRepository;
+
+  public ExtraFeaturesService(ExtraFeaturesRepository extraFeaturesRepository) {
+    this.extraFeaturesRepository = extraFeaturesRepository;
+  }
+
+  /**
+   * Retrieves all extra features.
+   *
+   * @return a list of all extra features
+   */
+  public List<ExtraFeaturesResponse> getAll() {
+    logger.debug("Retrieving all extra features");
+    return extraFeaturesRepository.findAll().stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Retrieves an extra feature by its ID.
+   *
+   * @param id the ID of the extra feature
+   * @return the extra feature
+   * @throws NotFoundException if no extra feature with the given ID exists
+   */
+  public ExtraFeaturesResponse getById(Long id) {
+    logger.debug("Retrieving extra feature with ID: {}", id);
+    return extraFeaturesRepository.findById(id)
+        .map(this::toResponse)
+        .orElseThrow(() -> new NotFoundException(
+            "Extra feature with ID " + id + " not found"));
+  }
+
+  /**
+   * Creates a new extra feature.
+   *
+   * @param request the extra feature data
+   * @return the created extra feature
+   */
+  public ExtraFeaturesResponse create(ExtraFeaturesRequest request) {
+    logger.info("Creating extra feature with name: {}", request.name());
+    ExtraFeatures entity = new ExtraFeatures();
+    entity.setName(request.name());
+    entity.setDescription(request.description());
+    ExtraFeatures saved = extraFeaturesRepository.save(entity);
+    logger.info("Created extra feature with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Updates an existing extra feature.
+   *
+   * @param id      the ID of the extra feature to update
+   * @param request the updated extra feature data
+   * @return the updated extra feature
+   * @throws NotFoundException if no extra feature with the given ID exists
+   */
+  public ExtraFeaturesResponse update(Long id, ExtraFeaturesRequest request) {
+    logger.info("Updating extra feature with ID: {}", id);
+    ExtraFeatures existing = extraFeaturesRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "Extra feature with ID " + id + " not found"));
+    existing.setName(request.name());
+    existing.setDescription(request.description());
+    ExtraFeatures saved = extraFeaturesRepository.save(existing);
+    logger.info("Updated extra feature with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Deletes an extra feature by its ID.
+   *
+   * @param id the ID of the extra feature to delete
+   * @throws NotFoundException if no extra feature with the given ID exists
+   */
+  public void deleteById(Long id) {
+    logger.info("Deleting extra feature with ID: {}", id);
+    if (!extraFeaturesRepository.existsById(id)) {
+      throw new NotFoundException(
+          "Extra feature with ID " + id + " not found");
+    }
+    extraFeaturesRepository.deleteById(id);
+    logger.info("Deleted extra feature with ID: {}", id);
+  }
+
+  /**
+   * Converts an {@link ExtraFeatures} entity to an {@link ExtraFeaturesResponse} DTO.
+   *
+   * @param entity the entity to convert
+   * @return the response DTO
+   */
+  private ExtraFeaturesResponse toResponse(ExtraFeatures entity) {
+    return new ExtraFeaturesResponse(entity.getId(), entity.getName(), entity.getDescription());
+  }
+}


### PR DESCRIPTION
  ## Summary
  - Full CRUD REST API for CarModels and ExtraFeatures entities
  - DTOs with validation and Swagger documentation

  ## Endpoints

  ### ExtraFeatures (`/api/extra-features`)
  - `GET /` — list all
  - `GET /{id}` — get by ID
  - `POST /` — create
  - `PUT /{id}` — update
  - `DELETE /{id}` — delete

  ### CarModels (`/api/car-models`)
  - `GET /` — list all
  - `GET /{id}` — get by ID
  - `POST /` — create (supports extra feature IDs)
  - `PUT /{id}` — update
  - `DELETE /{id}` — delete

