### PR TITLE
feat: add API layers for Accounts (incl. Users & Dealers)

### DIFF
--- a/src/main/java/no/ntnu/controller/AccountsController.java
+++ b/src/main/java/no/ntnu/controller/AccountsController.java
@@ -1,0 +1,116 @@
+package no.ntnu.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import no.ntnu.dto.accounts.AccountsResponse;
+import no.ntnu.dto.accounts.UpdatePasswordRequest;
+import no.ntnu.service.AccountsService;
+
+/**
+ * REST controller for managing accounts.
+ */
+@RestController
+@Validated
+@Tag(name = "Accounts", description = "Endpoints for managing accounts")
+@RequestMapping("/api/accounts")
+public class AccountsController {
+
+  private final AccountsService accountsService;
+
+  public AccountsController(AccountsService accountsService) {
+    this.accountsService = accountsService;
+  }
+
+  /**
+   * Retrieves all accounts.
+   *
+   * @return a list of all accounts
+   */
+  @GetMapping
+  @Operation(summary = "Get all accounts")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Accounts retrieved")
+  })
+  public ResponseEntity<List<AccountsResponse>> getAll() {
+    return ResponseEntity.ok(accountsService.getAll());
+  }
+
+  /**
+   * Retrieves an account by its ID.
+   *
+   * @param id the ID of the account
+   * @return the account
+   */
+  @GetMapping("/{id}")
+  @Operation(summary = "Get an account by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Account found"),
+      @ApiResponse(responseCode = "404", description = "Account not found")
+  })
+  public ResponseEntity<AccountsResponse> getById(
+      @Parameter(description = "ID of the account", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    return ResponseEntity.ok(accountsService.getById(id));
+  }
+
+  /**
+   * Updates the password for an account.
+   *
+   * @param id      the ID of the account
+   * @param request the password update request
+   * @return 204 No Content on success
+   */
+  @PutMapping("/{id}/password")
+  @Operation(summary = "Update an account's password")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Password updated"),
+      @ApiResponse(responseCode = "400", description = "Old password is incorrect"),
+      @ApiResponse(responseCode = "404", description = "Account not found")
+  })
+  public ResponseEntity<Void> updatePassword(
+      @Parameter(description = "ID of the account", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id,
+      @Valid @RequestBody UpdatePasswordRequest request) {
+    accountsService.updatePassword(id, request);
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * Soft-deletes an account by its ID.
+   *
+   * @param id the ID of the account to delete
+   * @return 204 No Content on success
+   */
+  @DeleteMapping("/{id}")
+  @Operation(summary = "Delete an account by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Account deleted"),
+      @ApiResponse(responseCode = "404", description = "Account not found")
+  })
+  public ResponseEntity<Void> deleteById(
+      @Parameter(description = "ID of the account", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    accountsService.deleteById(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/no/ntnu/controller/DealersController.java
+++ b/src/main/java/no/ntnu/controller/DealersController.java
@@ -1,0 +1,135 @@
+package no.ntnu.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import no.ntnu.dto.dealers.DealersRequest;
+import no.ntnu.dto.dealers.DealersResponse;
+import no.ntnu.service.DealersService;
+
+/**
+ * REST controller for managing dealers.
+ */
+@RestController
+@Validated
+@Tag(name = "Dealers", description = "Endpoints for managing dealers")
+@RequestMapping("/api/dealers")
+public class DealersController {
+
+  private final DealersService dealersService;
+
+  public DealersController(DealersService dealersService) {
+    this.dealersService = dealersService;
+  }
+
+  /**
+   * Retrieves all dealers.
+   *
+   * @return a list of all dealers
+   */
+  @GetMapping
+  @Operation(summary = "Get all dealers")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Dealers retrieved")
+  })
+  public ResponseEntity<List<DealersResponse>> getAll() {
+    return ResponseEntity.ok(dealersService.getAll());
+  }
+
+  /**
+   * Retrieves a dealer by its ID.
+   *
+   * @param id the ID of the dealer
+   * @return the dealer
+   */
+  @GetMapping("/{id}")
+  @Operation(summary = "Get a dealer by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Dealer found"),
+      @ApiResponse(responseCode = "404", description = "Dealer not found")
+  })
+  public ResponseEntity<DealersResponse> getById(
+      @Parameter(description = "ID of the dealer", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    return ResponseEntity.ok(dealersService.getById(id));
+  }
+
+  /**
+   * Creates a new dealer.
+   *
+   * @param request the dealer data
+   * @return the created dealer
+   */
+  @PostMapping
+  @Operation(summary = "Create a new dealer")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "Dealer created"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data")
+  })
+  public ResponseEntity<DealersResponse> create(
+      @Valid @RequestBody DealersRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(dealersService.create(request));
+  }
+
+  /**
+   * Updates an existing dealer.
+   *
+   * @param id      the ID of the dealer to update
+   * @param request the updated dealer data
+   * @return the updated dealer
+   */
+  @PutMapping("/{id}")
+  @Operation(summary = "Update a dealer by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Dealer updated"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data"),
+      @ApiResponse(responseCode = "404", description = "Dealer not found")
+  })
+  public ResponseEntity<DealersResponse> update(
+      @Parameter(description = "ID of the dealer", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id,
+      @Valid @RequestBody DealersRequest request) {
+    return ResponseEntity.ok(dealersService.update(id, request));
+  }
+
+  /**
+   * Soft-deletes a dealer by its ID.
+   *
+   * @param id the ID of the dealer to delete
+   * @return 204 No Content on success
+   */
+  @DeleteMapping("/{id}")
+  @Operation(summary = "Delete a dealer by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Dealer deleted"),
+      @ApiResponse(responseCode = "404", description = "Dealer not found")
+  })
+  public ResponseEntity<Void> deleteById(
+      @Parameter(description = "ID of the dealer", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    dealersService.deleteById(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/no/ntnu/controller/UsersController.java
+++ b/src/main/java/no/ntnu/controller/UsersController.java
@@ -1,0 +1,203 @@
+package no.ntnu.controller;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import no.ntnu.dto.users.UsersRequest;
+import no.ntnu.dto.users.UsersResponse;
+import no.ntnu.service.UsersService;
+
+/**
+ * REST controller for managing users.
+ */
+@RestController
+@Validated
+@Tag(name = "Users", description = "Endpoints for managing users")
+@RequestMapping("/api/users")
+public class UsersController {
+
+  private final UsersService usersService;
+
+  public UsersController(UsersService usersService) {
+    this.usersService = usersService;
+  }
+
+  /**
+   * Retrieves all users.
+   *
+   * @return a list of all users
+   */
+  @GetMapping
+  @Operation(summary = "Get all users")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Users retrieved")
+  })
+  public ResponseEntity<List<UsersResponse>> getAll() {
+    return ResponseEntity.ok(usersService.getAll());
+  }
+
+  /**
+   * Retrieves a user by its ID.
+   *
+   * @param id the ID of the user
+   * @return the user
+   */
+  @GetMapping("/{id}")
+  @Operation(summary = "Get a user by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "User found"),
+      @ApiResponse(responseCode = "404", description = "User not found")
+  })
+  public ResponseEntity<UsersResponse> getById(
+      @Parameter(description = "ID of the user", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    return ResponseEntity.ok(usersService.getById(id));
+  }
+
+  /**
+   * Creates a new user.
+   *
+   * @param request the user data
+   * @return the created user
+   */
+  @PostMapping
+  @Operation(summary = "Create a new user")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "User created"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data")
+  })
+  public ResponseEntity<UsersResponse> create(
+      @Valid @RequestBody UsersRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(usersService.create(request));
+  }
+
+  /**
+   * Updates an existing user.
+   *
+   * @param id      the ID of the user to update
+   * @param request the updated user data
+   * @return the updated user
+   */
+  @PutMapping("/{id}")
+  @Operation(summary = "Update a user by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "User updated"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data"),
+      @ApiResponse(responseCode = "404", description = "User not found")
+  })
+  public ResponseEntity<UsersResponse> update(
+      @Parameter(description = "ID of the user", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id,
+      @Valid @RequestBody UsersRequest request) {
+    return ResponseEntity.ok(usersService.update(id, request));
+  }
+
+  /**
+   * Soft-deletes a user by its ID.
+   *
+   * @param id the ID of the user to delete
+   * @return 204 No Content on success
+   */
+  @DeleteMapping("/{id}")
+  @Operation(summary = "Delete a user by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "User deleted"),
+      @ApiResponse(responseCode = "404", description = "User not found")
+  })
+  public ResponseEntity<Void> deleteById(
+      @Parameter(description = "ID of the user", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    usersService.deleteById(id);
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * Retrieves a user's favorite listing IDs.
+   *
+   * @param id the ID of the user
+   * @return a set of favorite listing IDs
+   */
+  @GetMapping("/{id}/favorites")
+  @Operation(summary = "Get a user's favorite listings")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Favorites retrieved"),
+      @ApiResponse(responseCode = "404", description = "User not found")
+  })
+  public ResponseEntity<Set<Long>> getFavorites(
+      @Parameter(description = "ID of the user", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    return ResponseEntity.ok(usersService.getFavorites(id));
+  }
+
+  /**
+   * Adds a listing to a user's favorites.
+   *
+   * @param id        the ID of the user
+   * @param listingId the ID of the listing to add
+   * @return 204 No Content on success
+   */
+  @PostMapping("/{id}/favorites/{listingId}")
+  @Operation(summary = "Add a listing to a user's favorites")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Favorite added"),
+      @ApiResponse(responseCode = "404", description = "User or listing not found")
+  })
+  public ResponseEntity<Void> addFavorite(
+      @Parameter(description = "ID of the user", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id,
+      @Parameter(description = "ID of the listing", required = true)
+      @Positive(message = "Listing ID must be positive")
+      @PathVariable Long listingId) {
+    usersService.addFavorite(id, listingId);
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * Removes a listing from a user's favorites.
+   *
+   * @param id        the ID of the user
+   * @param listingId the ID of the listing to remove
+   * @return 204 No Content on success
+   */
+  @DeleteMapping("/{id}/favorites/{listingId}")
+  @Operation(summary = "Remove a listing from a user's favorites")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Favorite removed"),
+      @ApiResponse(responseCode = "404", description = "User or listing not found")
+  })
+  public ResponseEntity<Void> removeFavorite(
+      @Parameter(description = "ID of the user", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id,
+      @Parameter(description = "ID of the listing", required = true)
+      @Positive(message = "Listing ID must be positive")
+      @PathVariable Long listingId) {
+    usersService.removeFavorite(id, listingId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/no/ntnu/dto/accounts/AccountsResponse.java
+++ b/src/main/java/no/ntnu/dto/accounts/AccountsResponse.java
@@ -1,0 +1,29 @@
+package no.ntnu.dto.accounts;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import no.ntnu.entity.Accounts;
+
+/**
+ * DTO for returning an {@link no.ntnu.entity.Accounts account} in API responses.
+ */
+@Schema(description = "Response body representing an account")
+public record AccountsResponse(
+
+    @Schema(description = "The ID of the account", example = "1")
+    Long id,
+
+    @Schema(description = "The email of the account", example = "user@example.com")
+    String email,
+
+    @Schema(description = "The phone number of the account", example = "+4712345678")
+    String phoneNumber,
+
+    @Schema(description = "The role of the account", example = "ROLE_USER")
+    Accounts.Role role,
+
+    @Schema(description = "The creation time of the account")
+    LocalDateTime createdAt
+
+) {}

--- a/src/main/java/no/ntnu/dto/accounts/UpdatePasswordRequest.java
+++ b/src/main/java/no/ntnu/dto/accounts/UpdatePasswordRequest.java
@@ -1,0 +1,22 @@
+package no.ntnu.dto.accounts;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO for updating an account's password.
+ */
+@Schema(description = "Request body for updating an account's password")
+public record UpdatePasswordRequest(
+
+    @NotBlank(message = "Old password is required")
+    @Schema(description = "The current password of the account")
+    String oldPassword,
+
+    @NotBlank(message = "New password is required")
+    @Size(min = 1, max = 255, message = "New password must be between 1 and 255 characters")
+    @Schema(description = "The new password for the account")
+    String newPassword
+
+) {}

--- a/src/main/java/no/ntnu/dto/dealers/DealersRequest.java
+++ b/src/main/java/no/ntnu/dto/dealers/DealersRequest.java
@@ -1,0 +1,34 @@
+package no.ntnu.dto.dealers;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO for creating or updating a {@link no.ntnu.entity.Dealers dealer}.
+ */
+@Schema(description = "Request body for creating or updating a dealer")
+public record DealersRequest(
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    @Size(max = 255, message = "Email must be at most 255 characters")
+    @Schema(description = "The email of the dealer", example = "dealer@motors.com")
+    String email,
+
+    @Size(max = 32, message = "Phone number must be at most 32 characters")
+    @Schema(description = "The phone number of the dealer", example = "+4798765432")
+    String phoneNumber,
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 1, max = 255, message = "Password must be between 1 and 255 characters")
+    @Schema(description = "The password of the dealer")
+    String password,
+
+    @NotBlank(message = "Company name is required")
+    @Size(max = 128, message = "Company name must be at most 128 characters")
+    @Schema(description = "The company name of the dealer", example = "Nordic Motors AS")
+    String companyName
+
+) {}

--- a/src/main/java/no/ntnu/dto/dealers/DealersResponse.java
+++ b/src/main/java/no/ntnu/dto/dealers/DealersResponse.java
@@ -1,0 +1,32 @@
+package no.ntnu.dto.dealers;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import no.ntnu.entity.Accounts;
+
+/**
+ * DTO for returning a {@link no.ntnu.entity.Dealers dealer} in API responses.
+ */
+@Schema(description = "Response body representing a dealer")
+public record DealersResponse(
+
+    @Schema(description = "The ID of the dealer", example = "1")
+    Long id,
+
+    @Schema(description = "The email of the dealer", example = "dealer@motors.com")
+    String email,
+
+    @Schema(description = "The phone number of the dealer", example = "+4798765432")
+    String phoneNumber,
+
+    @Schema(description = "The role of the dealer", example = "ROLE_DEALER")
+    Accounts.Role role,
+
+    @Schema(description = "The creation time of the account")
+    LocalDateTime createdAt,
+
+    @Schema(description = "The company name of the dealer", example = "Nordic Motors AS")
+    String companyName
+
+) {}

--- a/src/main/java/no/ntnu/dto/users/UsersRequest.java
+++ b/src/main/java/no/ntnu/dto/users/UsersRequest.java
@@ -1,0 +1,39 @@
+package no.ntnu.dto.users;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO for creating or updating a {@link no.ntnu.entity.Users user}.
+ */
+@Schema(description = "Request body for creating or updating a user")
+public record UsersRequest(
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    @Size(max = 255, message = "Email must be at most 255 characters")
+    @Schema(description = "The email of the user", example = "john@example.com")
+    String email,
+
+    @Size(max = 32, message = "Phone number must be at most 32 characters")
+    @Schema(description = "The phone number of the user", example = "+4712345678")
+    String phoneNumber,
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 1, max = 255, message = "Password must be between 1 and 255 characters")
+    @Schema(description = "The password of the user")
+    String password,
+
+    @NotBlank(message = "First name is required")
+    @Size(max = 64, message = "First name must be at most 64 characters")
+    @Schema(description = "The first name of the user", example = "John")
+    String firstName,
+
+    @NotBlank(message = "Last name is required")
+    @Size(max = 64, message = "Last name must be at most 64 characters")
+    @Schema(description = "The last name of the user", example = "Doe")
+    String lastName
+
+) {}

--- a/src/main/java/no/ntnu/dto/users/UsersResponse.java
+++ b/src/main/java/no/ntnu/dto/users/UsersResponse.java
@@ -1,0 +1,39 @@
+package no.ntnu.dto.users;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import no.ntnu.entity.Accounts;
+
+/**
+ * DTO for returning a {@link no.ntnu.entity.Users user} in API responses.
+ */
+@Schema(description = "Response body representing a user")
+public record UsersResponse(
+
+    @Schema(description = "The ID of the user", example = "1")
+    Long id,
+
+    @Schema(description = "The email of the user", example = "john@example.com")
+    String email,
+
+    @Schema(description = "The phone number of the user", example = "+4712345678")
+    String phoneNumber,
+
+    @Schema(description = "The role of the user", example = "ROLE_USER")
+    Accounts.Role role,
+
+    @Schema(description = "The creation time of the account")
+    LocalDateTime createdAt,
+
+    @Schema(description = "The first name of the user", example = "John")
+    String firstName,
+
+    @Schema(description = "The last name of the user", example = "Doe")
+    String lastName,
+
+    @Schema(description = "IDs of the user's favorite listings")
+    Set<Long> favoriteListingIds
+
+) {}

--- a/src/main/java/no/ntnu/exception/BadRequestException.java
+++ b/src/main/java/no/ntnu/exception/BadRequestException.java
@@ -1,0 +1,10 @@
+package no.ntnu.exception;
+
+/**
+ * Exception thrown when a request contains invalid data or fails a business rule.
+ */
+public class BadRequestException extends RuntimeException {
+  public BadRequestException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/no/ntnu/exception/GlobalExceptionHandler.java
+++ b/src/main/java/no/ntnu/exception/GlobalExceptionHandler.java
@@ -42,6 +42,19 @@ public class GlobalExceptionHandler {
   }
 
   /**
+   * Handles bad request exceptions from business logic validation.
+   * Returns a 400 Bad Request response with the exception message.
+   *
+   * @param ex the bad request exception
+   * @return ResponseEntity with status 400 and error message
+   */
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException ex) {
+    logger.error("{}", ex.getMessage());
+    return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+  }
+
+  /**
    * Handles all not-found exceptions.
    * Returns a 404 Not Found response with the exception message.
    *

--- a/src/main/java/no/ntnu/security/PasswordEncoderConfig.java
+++ b/src/main/java/no/ntnu/security/PasswordEncoderConfig.java
@@ -1,0 +1,18 @@
+package no.ntnu.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Configuration class providing the {@link PasswordEncoder} bean.
+ */
+@Configuration
+public class PasswordEncoderConfig {
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/no/ntnu/service/AccountsService.java
+++ b/src/main/java/no/ntnu/service/AccountsService.java
@@ -1,0 +1,113 @@
+package no.ntnu.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import no.ntnu.dto.accounts.AccountsResponse;
+import no.ntnu.dto.accounts.UpdatePasswordRequest;
+import no.ntnu.entity.Accounts;
+import no.ntnu.exception.BadRequestException;
+import no.ntnu.exception.NotFoundException;
+import no.ntnu.repository.AccountsRepository;
+
+/**
+ * Service for managing {@link Accounts} entities.
+ */
+@Service
+public class AccountsService {
+  private static final Logger logger = LoggerFactory.getLogger(AccountsService.class);
+
+  private final AccountsRepository accountsRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  public AccountsService(AccountsRepository accountsRepository,
+      PasswordEncoder passwordEncoder) {
+    this.accountsRepository = accountsRepository;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  /**
+   * Retrieves all accounts.
+   *
+   * @return a list of all accounts
+   */
+  public List<AccountsResponse> getAll() {
+    logger.debug("Retrieving all accounts");
+    return accountsRepository.findAll().stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Retrieves an account by its ID.
+   *
+   * @param id the ID of the account
+   * @return the account
+   * @throws NotFoundException if no account with the given ID exists
+   */
+  public AccountsResponse getById(Long id) {
+    logger.debug("Retrieving account with ID: {}", id);
+    return accountsRepository.findById(id)
+        .map(this::toResponse)
+        .orElseThrow(() -> new NotFoundException(
+            "Account with ID " + id + " not found"));
+  }
+
+  /**
+   * Soft-deletes an account by its ID.
+   *
+   * @param id the ID of the account to delete
+   * @throws NotFoundException if no account with the given ID exists
+   */
+  public void deleteById(Long id) {
+    logger.info("Deleting account with ID: {}", id);
+    Accounts existing = accountsRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "Account with ID " + id + " not found"));
+    existing.setDeleted(true);
+    accountsRepository.save(existing);
+    logger.info("Deleted account with ID: {}", id);
+  }
+
+  /**
+   * Updates the password for an account.
+   *
+   * @param id      the ID of the account
+   * @param request the password update request
+   * @throws NotFoundException if no account with the given ID exists
+   * @throws IllegalArgumentException if the old password does not match
+   */
+  public void updatePassword(Long id, UpdatePasswordRequest request) {
+    logger.info("Updating password for account with ID: {}", id);
+    Accounts existing = accountsRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "Account with ID " + id + " not found"));
+    if (!passwordEncoder.matches(request.oldPassword(), existing.getPassword())) {
+      logger.warn("Password update failed for account with ID: {}: incorrect old password", id);
+      throw new BadRequestException("Old password is incorrect");
+    }
+    existing.setPassword(passwordEncoder.encode(request.newPassword()));
+    accountsRepository.save(existing);
+    logger.info("Updated password for account with ID: {}", id);
+  }
+
+  /**
+   * Converts an {@link Accounts} entity to an {@link AccountsResponse} DTO.
+   *
+   * @param entity the entity to convert
+   * @return the response DTO
+   */
+  private AccountsResponse toResponse(Accounts entity) {
+    return new AccountsResponse(
+        entity.getId(),
+        entity.getEmail(),
+        entity.getPhoneNumber(),
+        entity.getRole(),
+        entity.getCreatedAt());
+  }
+}

--- a/src/main/java/no/ntnu/service/DealersService.java
+++ b/src/main/java/no/ntnu/service/DealersService.java
@@ -1,0 +1,137 @@
+package no.ntnu.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import no.ntnu.dto.dealers.DealersRequest;
+import no.ntnu.dto.dealers.DealersResponse;
+import no.ntnu.entity.Dealers;
+import no.ntnu.exception.NotFoundException;
+import no.ntnu.repository.DealersRepository;
+
+/**
+ * Service for managing {@link Dealers} entities.
+ */
+@Service
+public class DealersService {
+  private static final Logger logger = LoggerFactory.getLogger(DealersService.class);
+
+  private final DealersRepository dealersRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  public DealersService(DealersRepository dealersRepository,
+      PasswordEncoder passwordEncoder) {
+    this.dealersRepository = dealersRepository;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  /**
+   * Retrieves all dealers.
+   *
+   * @return a list of all dealers
+   */
+  public List<DealersResponse> getAll() {
+    logger.debug("Retrieving all dealers");
+    return dealersRepository.findAll().stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Retrieves a dealer by its ID.
+   *
+   * @param id the ID of the dealer
+   * @return the dealer
+   * @throws NotFoundException if no dealer with the given ID exists
+   */
+  public DealersResponse getById(Long id) {
+    logger.debug("Retrieving dealer with ID: {}", id);
+    return dealersRepository.findById(id)
+        .map(this::toResponse)
+        .orElseThrow(() -> new NotFoundException(
+            "Dealer with ID " + id + " not found"));
+  }
+
+  /**
+   * Creates a new dealer.
+   *
+   * @param request the dealer data
+   * @return the created dealer
+   */
+  public DealersResponse create(DealersRequest request) {
+    logger.info("Creating dealer with email: {}", request.email());
+    Dealers entity = new Dealers();
+    applyRequest(entity, request);
+    Dealers saved = dealersRepository.save(entity);
+    logger.info("Created dealer with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Updates an existing dealer.
+   *
+   * @param id      the ID of the dealer to update
+   * @param request the updated dealer data
+   * @return the updated dealer
+   * @throws NotFoundException if no dealer with the given ID exists
+   */
+  public DealersResponse update(Long id, DealersRequest request) {
+    logger.info("Updating dealer with ID: {}", id);
+    Dealers existing = dealersRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "Dealer with ID " + id + " not found"));
+    applyRequest(existing, request);
+    Dealers saved = dealersRepository.save(existing);
+    logger.info("Updated dealer with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Soft-deletes a dealer by its ID.
+   *
+   * @param id the ID of the dealer to delete
+   * @throws NotFoundException if no dealer with the given ID exists
+   */
+  public void deleteById(Long id) {
+    logger.info("Deleting dealer with ID: {}", id);
+    Dealers existing = dealersRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "Dealer with ID " + id + " not found"));
+    existing.setDeleted(true);
+    dealersRepository.save(existing);
+    logger.info("Deleted dealer with ID: {}", id);
+  }
+
+  /**
+   * Applies the fields from a request DTO to a dealer entity.
+   *
+   * @param entity  the entity to update
+   * @param request the request data
+   */
+  private void applyRequest(Dealers entity, DealersRequest request) {
+    entity.setEmail(request.email());
+    entity.setPhoneNumber(request.phoneNumber());
+    entity.setPassword(passwordEncoder.encode(request.password()));
+    entity.setCompanyName(request.companyName());
+  }
+
+  /**
+   * Converts a {@link Dealers} entity to a {@link DealersResponse} DTO.
+   *
+   * @param entity the entity to convert
+   * @return the response DTO
+   */
+  private DealersResponse toResponse(Dealers entity) {
+    return new DealersResponse(
+        entity.getId(),
+        entity.getEmail(),
+        entity.getPhoneNumber(),
+        entity.getRole(),
+        entity.getCreatedAt(),
+        entity.getCompanyName());
+  }
+}

--- a/src/main/java/no/ntnu/service/UsersService.java
+++ b/src/main/java/no/ntnu/service/UsersService.java
@@ -1,0 +1,218 @@
+package no.ntnu.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import no.ntnu.dto.users.UsersRequest;
+import no.ntnu.dto.users.UsersResponse;
+import no.ntnu.entity.Listings;
+import no.ntnu.entity.Users;
+import no.ntnu.exception.NotFoundException;
+import no.ntnu.repository.ListingsRepository;
+import no.ntnu.repository.UsersRepository;
+
+/**
+ * Service for managing {@link Users} entities.
+ */
+@Service
+public class UsersService {
+  private static final Logger logger = LoggerFactory.getLogger(UsersService.class);
+
+  private final UsersRepository usersRepository;
+  private final ListingsRepository listingsRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  public UsersService(UsersRepository usersRepository,
+      ListingsRepository listingsRepository,
+      PasswordEncoder passwordEncoder) {
+    this.usersRepository = usersRepository;
+    this.listingsRepository = listingsRepository;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  /**
+   * Retrieves all users.
+   *
+   * @return a list of all users
+   */
+  public List<UsersResponse> getAll() {
+    logger.debug("Retrieving all users");
+    return usersRepository.findAll().stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Retrieves a user by its ID.
+   *
+   * @param id the ID of the user
+   * @return the user
+   * @throws NotFoundException if no user with the given ID exists
+   */
+  public UsersResponse getById(Long id) {
+    logger.debug("Retrieving user with ID: {}", id);
+    return usersRepository.findById(id)
+        .map(this::toResponse)
+        .orElseThrow(() -> new NotFoundException(
+            "User with ID " + id + " not found"));
+  }
+
+  /**
+   * Creates a new user.
+   *
+   * @param request the user data
+   * @return the created user
+   */
+  public UsersResponse create(UsersRequest request) {
+    logger.info("Creating user with email: {}", request.email());
+    Users entity = new Users();
+    applyRequest(entity, request);
+    Users saved = usersRepository.save(entity);
+    logger.info("Created user with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Updates an existing user.
+   *
+   * @param id      the ID of the user to update
+   * @param request the updated user data
+   * @return the updated user
+   * @throws NotFoundException if no user with the given ID exists
+   */
+  public UsersResponse update(Long id, UsersRequest request) {
+    logger.info("Updating user with ID: {}", id);
+    Users existing = usersRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "User with ID " + id + " not found"));
+    applyRequest(existing, request);
+    Users saved = usersRepository.save(existing);
+    logger.info("Updated user with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Soft-deletes a user by its ID.
+   *
+   * @param id the ID of the user to delete
+   * @throws NotFoundException if no user with the given ID exists
+   */
+  public void deleteById(Long id) {
+    logger.info("Deleting user with ID: {}", id);
+    Users existing = usersRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "User with ID " + id + " not found"));
+    existing.setDeleted(true);
+    usersRepository.save(existing);
+    logger.info("Deleted user with ID: {}", id);
+  }
+
+  /**
+   * Retrieves the favorite listing IDs for a user.
+   *
+   * @param id the ID of the user
+   * @return a set of favorite listing IDs
+   * @throws NotFoundException if no user with the given ID exists
+   */
+  public Set<Long> getFavorites(Long id) {
+    logger.debug("Retrieving favorites for user with ID: {}", id);
+    Users user = usersRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "User with ID " + id + " not found"));
+    return user.getFavoriteListings() == null
+        ? Set.of()
+        : user.getFavoriteListings().stream()
+            .map(Listings::getId)
+            .collect(Collectors.toSet());
+  }
+
+  /**
+   * Adds a listing to a user's favorites.
+   *
+   * @param userId    the ID of the user
+   * @param listingId the ID of the listing to add
+   * @throws NotFoundException if the user or listing does not exist
+   */
+  public void addFavorite(Long userId, Long listingId) {
+    logger.info("Adding listing {} to favorites for user {}", listingId, userId);
+    Users user = usersRepository.findById(userId)
+        .orElseThrow(() -> new NotFoundException(
+            "User with ID " + userId + " not found"));
+    Listings listing = listingsRepository.findById(listingId)
+        .orElseThrow(() -> new NotFoundException(
+            "Listing with ID " + listingId + " not found"));
+    if (user.getFavoriteListings() == null) {
+      user.setFavoriteListings(new HashSet<>());
+    }
+    user.getFavoriteListings().add(listing);
+    usersRepository.save(user);
+    logger.info("Added listing {} to favorites for user {}", listingId, userId);
+  }
+
+  /**
+   * Removes a listing from a user's favorites.
+   *
+   * @param userId    the ID of the user
+   * @param listingId the ID of the listing to remove
+   * @throws NotFoundException if the user or listing does not exist
+   */
+  public void removeFavorite(Long userId, Long listingId) {
+    logger.info("Removing listing {} from favorites for user {}", listingId, userId);
+    Users user = usersRepository.findById(userId)
+        .orElseThrow(() -> new NotFoundException(
+            "User with ID " + userId + " not found"));
+    Listings listing = listingsRepository.findById(listingId)
+        .orElseThrow(() -> new NotFoundException(
+            "Listing with ID " + listingId + " not found"));
+    if (user.getFavoriteListings() != null) {
+      user.getFavoriteListings().remove(listing);
+      usersRepository.save(user);
+    }
+    logger.info("Removed listing {} from favorites for user {}", listingId, userId);
+  }
+
+  /**
+   * Applies the fields from a request DTO to a user entity.
+   *
+   * @param entity  the entity to update
+   * @param request the request data
+   */
+  private void applyRequest(Users entity, UsersRequest request) {
+    entity.setEmail(request.email());
+    entity.setPhoneNumber(request.phoneNumber());
+    entity.setPassword(passwordEncoder.encode(request.password()));
+    entity.setFirstName(request.firstName());
+    entity.setLastName(request.lastName());
+  }
+
+  /**
+   * Converts a {@link Users} entity to a {@link UsersResponse} DTO.
+   *
+   * @param entity the entity to convert
+   * @return the response DTO
+   */
+  private UsersResponse toResponse(Users entity) {
+    Set<Long> favoriteListingIds = entity.getFavoriteListings() == null
+        ? Set.of()
+        : entity.getFavoriteListings().stream()
+            .map(Listings::getId)
+            .collect(Collectors.toSet());
+
+    return new UsersResponse(
+        entity.getId(),
+        entity.getEmail(),
+        entity.getPhoneNumber(),
+        entity.getRole(),
+        entity.getCreatedAt(),
+        entity.getFirstName(),
+        entity.getLastName(),
+        favoriteListingIds);
+  }
+}


### PR DESCRIPTION
## Summary
  - Full CRUD REST API for Accounts, Users, and Dealers entities
  - DTOs with validation and Swagger documentation
  - Service layer with soft delete, password hashing, and user favorites
  - BadRequestException for business logic validation errors
  - PasswordEncoder bean for BCrypt hashing

  ## Endpoints

  ### Accounts (`/api/accounts`)
  - `GET /` — list all
  - `GET /{id}` — get by ID
  - `PUT /{id}/password` — update password
  - `DELETE /{id}` — soft delete

  ### Users (`/api/users`)
  - `GET /` — list all
  - `GET /{id}` — get by ID
  - `POST /` — create
  - `PUT /{id}` — update
  - `DELETE /{id}` — soft delete
  - `GET /{id}/favorites` — list favorite listing IDs
  - `POST /{id}/favorites/{listingId}` — add favorite
  - `DELETE /{id}/favorites/{listingId}` — remove favorite

  ### Dealers (`/api/dealers`)
  - `GET /` — list all
  - `GET /{id}` — get by ID
  - `POST /` — create
  - `PUT /{id}` — update
  - `DELETE /{id}` — soft delete
