### PR TITLE
feat: add API layers for Listings and Orders

### DIFF
--- a/src/main/java/no/ntnu/controller/ListingsController.java
+++ b/src/main/java/no/ntnu/controller/ListingsController.java
@@ -1,0 +1,154 @@
+package no.ntnu.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import no.ntnu.dto.listings.ListingsRequest;
+import no.ntnu.dto.listings.ListingsResponse;
+import no.ntnu.service.ListingsService;
+
+/**
+ * REST controller for managing listings.
+ */
+@RestController
+@Validated
+@Tag(name = "Listings", description = "Endpoints for managing listings")
+@RequestMapping("/api/listings")
+public class ListingsController {
+
+  private final ListingsService listingsService;
+
+  public ListingsController(ListingsService listingsService) {
+    this.listingsService = listingsService;
+  }
+
+  /**
+   * Retrieves all listings.
+   *
+   * @return a list of all listings
+   */
+  @GetMapping
+  @Operation(summary = "Get all listings")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Listings retrieved")
+  })
+  public ResponseEntity<List<ListingsResponse>> getAll() {
+    return ResponseEntity.ok(listingsService.getAll());
+  }
+
+  /**
+   * Retrieves a listing by its ID.
+   *
+   * @param id the ID of the listing
+   * @return the listing
+   */
+  @GetMapping("/{id}")
+  @Operation(summary = "Get a listing by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Listing found"),
+      @ApiResponse(responseCode = "404", description = "Listing not found")
+  })
+  public ResponseEntity<ListingsResponse> getById(
+      @Parameter(description = "ID of the listing", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    return ResponseEntity.ok(listingsService.getById(id));
+  }
+
+  /**
+   * Retrieves all listings for a given dealer.
+   *
+   * @param dealerId the ID of the dealer
+   * @return a list of listings for the dealer
+   */
+  @GetMapping("/dealer/{dealerId}")
+  @Operation(summary = "Get all listings for a dealer")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Listings retrieved"),
+      @ApiResponse(responseCode = "404", description = "Dealer not found")
+  })
+  public ResponseEntity<List<ListingsResponse>> getByDealerId(
+      @Parameter(description = "ID of the dealer", required = true)
+      @Positive(message = "Dealer ID must be positive")
+      @PathVariable Long dealerId) {
+    return ResponseEntity.ok(listingsService.getByDealerId(dealerId));
+  }
+
+  /**
+   * Creates a new listing.
+   *
+   * @param request the listing data
+   * @return the created listing
+   */
+  @PostMapping
+  @Operation(summary = "Create a new listing")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "Listing created"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data")
+  })
+  public ResponseEntity<ListingsResponse> create(
+      @Valid @RequestBody ListingsRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(listingsService.create(request));
+  }
+
+  /**
+   * Updates an existing listing.
+   *
+   * @param id      the ID of the listing to update
+   * @param request the updated listing data
+   * @return the updated listing
+   */
+  @PutMapping("/{id}")
+  @Operation(summary = "Update a listing by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Listing updated"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data"),
+      @ApiResponse(responseCode = "404", description = "Listing not found")
+  })
+  public ResponseEntity<ListingsResponse> update(
+      @Parameter(description = "ID of the listing", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id,
+      @Valid @RequestBody ListingsRequest request) {
+    return ResponseEntity.ok(listingsService.update(id, request));
+  }
+
+  /**
+   * Deletes a listing by its ID.
+   *
+   * @param id the ID of the listing to delete
+   * @return 204 No Content on success
+   */
+  @DeleteMapping("/{id}")
+  @Operation(summary = "Delete a listing by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Listing deleted"),
+      @ApiResponse(responseCode = "404", description = "Listing not found")
+  })
+  public ResponseEntity<Void> deleteById(
+      @Parameter(description = "ID of the listing", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    listingsService.deleteById(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/no/ntnu/controller/OrdersController.java
+++ b/src/main/java/no/ntnu/controller/OrdersController.java
@@ -1,0 +1,194 @@
+package no.ntnu.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import no.ntnu.dto.orders.OrdersRequest;
+import no.ntnu.dto.orders.OrdersResponse;
+import no.ntnu.entity.Orders;
+import no.ntnu.service.OrdersService;
+
+/**
+ * REST controller for managing orders.
+ */
+@RestController
+@Validated
+@Tag(name = "Orders", description = "Endpoints for managing orders")
+@RequestMapping("/api/orders")
+public class OrdersController {
+
+  private final OrdersService ordersService;
+
+  public OrdersController(OrdersService ordersService) {
+    this.ordersService = ordersService;
+  }
+
+  /**
+   * Retrieves all orders.
+   *
+   * @return a list of all orders
+   */
+  @GetMapping
+  @Operation(summary = "Get all orders")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Orders retrieved")
+  })
+  public ResponseEntity<List<OrdersResponse>> getAll() {
+    return ResponseEntity.ok(ordersService.getAll());
+  }
+
+  /**
+   * Retrieves an order by its ID.
+   *
+   * @param id the ID of the order
+   * @return the order
+   */
+  @GetMapping("/{id}")
+  @Operation(summary = "Get an order by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Order found"),
+      @ApiResponse(responseCode = "404", description = "Order not found")
+  })
+  public ResponseEntity<OrdersResponse> getById(
+      @Parameter(description = "ID of the order", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    return ResponseEntity.ok(ordersService.getById(id));
+  }
+
+  /**
+   * Retrieves all orders for a given buyer.
+   *
+   * @param userId the ID of the buyer
+   * @return a list of orders for the buyer
+   */
+  @GetMapping("/user/{userId}")
+  @Operation(summary = "Get all orders for a user")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Orders retrieved"),
+      @ApiResponse(responseCode = "404", description = "User not found")
+  })
+  public ResponseEntity<List<OrdersResponse>> getByUserId(
+      @Parameter(description = "ID of the user", required = true)
+      @Positive(message = "User ID must be positive")
+      @PathVariable Long userId) {
+    return ResponseEntity.ok(ordersService.getByUserId(userId));
+  }
+
+  /**
+   * Retrieves all orders for a given listing.
+   *
+   * @param listingId the ID of the listing
+   * @return a list of orders for the listing
+   */
+  @GetMapping("/listing/{listingId}")
+  @Operation(summary = "Get all orders for a listing")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Orders retrieved"),
+      @ApiResponse(responseCode = "404", description = "Listing not found")
+  })
+  public ResponseEntity<List<OrdersResponse>> getByListingId(
+      @Parameter(description = "ID of the listing", required = true)
+      @Positive(message = "Listing ID must be positive")
+      @PathVariable Long listingId) {
+    return ResponseEntity.ok(ordersService.getByListingId(listingId));
+  }
+
+  /**
+   * Retrieves all orders for a given dealer.
+   *
+   * @param dealerId the ID of the dealer
+   * @return a list of orders for the dealer
+   */
+  @GetMapping("/dealer/{dealerId}")
+  @Operation(summary = "Get all orders for a dealer")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Orders retrieved")
+  })
+  public ResponseEntity<List<OrdersResponse>> getByDealerId(
+      @Parameter(description = "ID of the dealer", required = true)
+      @Positive(message = "Dealer ID must be positive")
+      @PathVariable Long dealerId) {
+    return ResponseEntity.ok(ordersService.getByDealerId(dealerId));
+  }
+
+  /**
+   * Creates a new order.
+   *
+   * @param request the order data
+   * @return the created order
+   */
+  @PostMapping
+  @Operation(summary = "Create a new order")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "Order created"),
+      @ApiResponse(responseCode = "400", description = "Invalid input data"),
+      @ApiResponse(responseCode = "404", description = "User or listing not found")
+  })
+  public ResponseEntity<OrdersResponse> create(
+      @Valid @RequestBody OrdersRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ordersService.create(request));
+  }
+
+  /**
+   * Updates the status of an order.
+   *
+   * @param id     the ID of the order
+   * @param status the new status
+   * @return the updated order
+   */
+  @PatchMapping("/{id}/status")
+  @Operation(summary = "Update the status of an order")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Order status updated"),
+      @ApiResponse(responseCode = "404", description = "Order not found")
+  })
+  public ResponseEntity<OrdersResponse> updateStatus(
+      @Parameter(description = "ID of the order", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id,
+      @Parameter(description = "The new status", required = true)
+      @RequestParam Orders.Status status) {
+    return ResponseEntity.ok(ordersService.updateStatus(id, status));
+  }
+
+  /**
+   * Deletes an order by its ID.
+   *
+   * @param id the ID of the order to delete
+   * @return 204 No Content on success
+   */
+  @DeleteMapping("/{id}")
+  @Operation(summary = "Delete an order by ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Order deleted"),
+      @ApiResponse(responseCode = "404", description = "Order not found")
+  })
+  public ResponseEntity<Void> deleteById(
+      @Parameter(description = "ID of the order", required = true)
+      @Positive(message = "ID must be positive")
+      @PathVariable Long id) {
+    ordersService.deleteById(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/no/ntnu/dto/listings/ListingsRequest.java
+++ b/src/main/java/no/ntnu/dto/listings/ListingsRequest.java
@@ -1,0 +1,66 @@
+package no.ntnu.dto.listings;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import no.ntnu.entity.Listings;
+
+/**
+ * DTO for creating or updating a {@link no.ntnu.entity.Listings listing}.
+ */
+@Schema(description = "Request body for creating or updating a listing")
+public record ListingsRequest(
+
+    @NotNull(message = "Car model ID is required")
+    @Positive(message = "Car model ID must be positive")
+    @Schema(description = "The ID of the car model", example = "1")
+    Long carModelId,
+
+    @NotNull(message = "Dealer ID is required")
+    @Positive(message = "Dealer ID must be positive")
+    @Schema(description = "The ID of the dealer", example = "1")
+    Long dealerId,
+
+    @Size(max = 7, message = "Plate number must be at most 7 characters")
+    @Schema(description = "The plate number of the car", example = "AB12345")
+    String plateNumber,
+
+    @NotNull(message = "Price is required")
+    @Min(value = 0, message = "Price must be non-negative")
+    @Schema(description = "The price of the car", example = "499000.00")
+    BigDecimal price,
+
+    @Schema(description = "The availability status of the listing", example = "AVAILABLE")
+    Listings.Availability availability,
+
+    @Schema(description = "The date from which the car is available")
+    LocalDateTime availableFrom,
+
+    @Schema(description = "Whether the listing is visible to buyers", example = "true")
+    Boolean visible,
+
+    @NotBlank(message = "Color is required")
+    @Schema(description = "The color of the car", example = "Black")
+    String color,
+
+    @NotNull(message = "Condition is required")
+    @Schema(description = "Whether the car is new or secondhand", example = "NEW")
+    Listings.Condition condition,
+
+    @Min(value = 0, message = "Mileage must be non-negative")
+    @Schema(description = "The mileage of the car in kilometers", example = "0")
+    int mileage,
+
+    @Schema(description = "URL or path to the car image")
+    String imageUrl,
+
+    @Schema(description = "URL to the original advertisement the image was sourced from")
+    String sourceUrl
+
+) {}

--- a/src/main/java/no/ntnu/dto/listings/ListingsResponse.java
+++ b/src/main/java/no/ntnu/dto/listings/ListingsResponse.java
@@ -1,0 +1,56 @@
+package no.ntnu.dto.listings;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import no.ntnu.dto.carmodels.CarModelsResponse;
+import no.ntnu.dto.dealers.DealersResponse;
+import no.ntnu.entity.Listings;
+
+/**
+ * DTO for returning a {@link no.ntnu.entity.Listings listing} in API responses.
+ */
+@Schema(description = "Response body representing a listing")
+public record ListingsResponse(
+
+    @Schema(description = "The ID of the listing", example = "1")
+    Long id,
+
+    @Schema(description = "The car model of this listing")
+    CarModelsResponse carModel,
+
+    @Schema(description = "The dealer selling this car")
+    DealersResponse dealer,
+
+    @Schema(description = "The plate number of the car", example = "AB12345")
+    String plateNumber,
+
+    @Schema(description = "The price of the car", example = "499000.00")
+    BigDecimal price,
+
+    @Schema(description = "The availability status of the listing", example = "AVAILABLE")
+    Listings.Availability availability,
+
+    @Schema(description = "The date from which the car is available")
+    LocalDateTime availableFrom,
+
+    @Schema(description = "Whether the listing is visible to buyers", example = "true")
+    boolean visible,
+
+    @Schema(description = "The color of the car", example = "Black")
+    String color,
+
+    @Schema(description = "Whether the car is new or secondhand", example = "NEW")
+    Listings.Condition condition,
+
+    @Schema(description = "The mileage of the car in kilometers", example = "0")
+    int mileage,
+
+    @Schema(description = "URL or path to the car image")
+    String imageUrl,
+
+    @Schema(description = "URL to the original advertisement the image was sourced from")
+    String sourceUrl
+
+) {}

--- a/src/main/java/no/ntnu/dto/orders/OrdersRequest.java
+++ b/src/main/java/no/ntnu/dto/orders/OrdersRequest.java
@@ -1,0 +1,23 @@
+package no.ntnu.dto.orders;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+/**
+ * DTO for creating an {@link no.ntnu.entity.Orders order}.
+ */
+@Schema(description = "Request body for creating an order")
+public record OrdersRequest(
+
+    @NotNull(message = "Buyer ID is required")
+    @Positive(message = "Buyer ID must be positive")
+    @Schema(description = "The ID of the buyer", example = "1")
+    Long buyerId,
+
+    @NotNull(message = "Listing ID is required")
+    @Positive(message = "Listing ID must be positive")
+    @Schema(description = "The ID of the listing", example = "1")
+    Long listingId
+
+) {}

--- a/src/main/java/no/ntnu/dto/orders/OrdersResponse.java
+++ b/src/main/java/no/ntnu/dto/orders/OrdersResponse.java
@@ -1,0 +1,35 @@
+package no.ntnu.dto.orders;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import no.ntnu.dto.listings.ListingsResponse;
+import no.ntnu.dto.users.UsersResponse;
+import no.ntnu.entity.Orders;
+
+/**
+ * DTO for returning an {@link no.ntnu.entity.Orders order} in API responses.
+ */
+@Schema(description = "Response body representing an order")
+public record OrdersResponse(
+
+    @Schema(description = "The ID of the order", example = "1")
+    Long id,
+
+    @Schema(description = "The buyer who placed the order")
+    UsersResponse buyer,
+
+    @Schema(description = "The listing being purchased")
+    ListingsResponse listing,
+
+    @Schema(description = "The purchase price at the time of order", example = "499000.00")
+    BigDecimal purchasePrice,
+
+    @Schema(description = "The date the order was placed")
+    LocalDateTime orderedAt,
+
+    @Schema(description = "The status of the order", example = "PENDING")
+    Orders.Status status
+
+) {}

--- a/src/main/java/no/ntnu/entity/Orders.java
+++ b/src/main/java/no/ntnu/entity/Orders.java
@@ -3,6 +3,8 @@ package no.ntnu.entity;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,8 +20,15 @@ import jakarta.persistence.PrePersist;
 /**
  * Represents a car purchase order, linking a {@link Users buyer}
  * to a {@link Listings listing}.
+ *
+ * <p>
+ * This entity uses soft deletion via the {@code isDeleted} field.
+ * The {@code @SQLRestriction} annotation automatically filters out deleted
+ * orders from all standard JPA queries.
+ * </p>
  */
 @Entity
+@SQLRestriction("is_deleted = false")
 public class Orders {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,6 +57,10 @@ public class Orders {
   @Enumerated(EnumType.STRING)
   @Schema(description = "The status of the order")
   private Status status = Status.PENDING;
+
+  @Column(nullable = false)
+  @Schema(description = "Boolean indicating if the order is deleted")
+  private boolean isDeleted = false;
 
   @PrePersist
   protected void onCreate() {
@@ -104,5 +117,13 @@ public class Orders {
 
   public void setStatus(Status status) {
     this.status = status;
+  }
+
+  public boolean isDeleted() {
+    return isDeleted;
+  }
+
+  public void setDeleted(boolean isDeleted) {
+    this.isDeleted = isDeleted;
   }
 }

--- a/src/main/java/no/ntnu/repository/ListingsRepository.java
+++ b/src/main/java/no/ntnu/repository/ListingsRepository.java
@@ -1,5 +1,7 @@
 package no.ntnu.repository;
 
+import java.util.List;
+
 import no.ntnu.entity.Listings;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * Repository for the {@link Listings} entity.
  */
 public interface ListingsRepository extends JpaRepository<Listings, Long> {
+  List<Listings> findByDealerId(Long dealerId);
 }

--- a/src/main/java/no/ntnu/repository/OrdersRepository.java
+++ b/src/main/java/no/ntnu/repository/OrdersRepository.java
@@ -1,5 +1,7 @@
 package no.ntnu.repository;
 
+import java.util.List;
+
 import no.ntnu.entity.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * Repository for the {@link Orders} entity.
  */
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
+  List<Orders> findByBuyerId(Long buyerId);
+
+  List<Orders> findByListingId(Long listingId);
+
+  List<Orders> findByListingDealerId(Long dealerId);
 }

--- a/src/main/java/no/ntnu/service/ListingsService.java
+++ b/src/main/java/no/ntnu/service/ListingsService.java
@@ -1,0 +1,195 @@
+package no.ntnu.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import no.ntnu.dto.carmodels.CarModelsResponse;
+import no.ntnu.dto.dealers.DealersResponse;
+import no.ntnu.dto.extrafeatures.ExtraFeaturesResponse;
+import no.ntnu.dto.listings.ListingsRequest;
+import no.ntnu.dto.listings.ListingsResponse;
+import no.ntnu.entity.CarModels;
+import no.ntnu.entity.Dealers;
+import no.ntnu.entity.Listings;
+import no.ntnu.exception.NotFoundException;
+import no.ntnu.repository.CarModelsRepository;
+import no.ntnu.repository.DealersRepository;
+import no.ntnu.repository.ListingsRepository;
+
+/**
+ * Service for managing {@link Listings} entities.
+ */
+@Service
+public class ListingsService {
+  private static final Logger logger = LoggerFactory.getLogger(ListingsService.class);
+
+  private final ListingsRepository listingsRepository;
+  private final CarModelsRepository carModelsRepository;
+  private final DealersRepository dealersRepository;
+
+  public ListingsService(ListingsRepository listingsRepository,
+      CarModelsRepository carModelsRepository,
+      DealersRepository dealersRepository) {
+    this.listingsRepository = listingsRepository;
+    this.carModelsRepository = carModelsRepository;
+    this.dealersRepository = dealersRepository;
+  }
+
+  /**
+   * Retrieves all listings.
+   *
+   * @return a list of all listings
+   */
+  public List<ListingsResponse> getAll() {
+    logger.debug("Retrieving all listings");
+    return listingsRepository.findAll().stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Retrieves a listing by its ID.
+   *
+   * @param id the ID of the listing
+   * @return the listing
+   * @throws NotFoundException if no listing with the given ID exists
+   */
+  public ListingsResponse getById(Long id) {
+    logger.debug("Retrieving listing with ID: {}", id);
+    return listingsRepository.findById(id)
+        .map(this::toResponse)
+        .orElseThrow(() -> new NotFoundException(
+            "Listing with ID " + id + " not found"));
+  }
+
+  /**
+   * Retrieves all listings for a given dealer.
+   *
+   * @param dealerId the ID of the dealer
+   * @return a list of listings for the dealer
+   * @throws NotFoundException if no dealer with the given ID exists
+   */
+  public List<ListingsResponse> getByDealerId(Long dealerId) {
+    logger.debug("Retrieving listings for dealer with ID: {}", dealerId);
+    if (!dealersRepository.existsById(dealerId)) {
+      throw new NotFoundException("Dealer with ID " + dealerId + " not found");
+    }
+    return listingsRepository.findByDealerId(dealerId).stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Creates a new listing.
+   *
+   * @param request the listing data
+   * @return the created listing
+   */
+  public ListingsResponse create(ListingsRequest request) {
+    logger.info("Creating listing for car model {} by dealer {}", request.carModelId(), request.dealerId());
+    Listings entity = new Listings();
+    applyRequest(entity, request);
+    Listings saved = listingsRepository.save(entity);
+    logger.info("Created listing with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Updates an existing listing.
+   *
+   * @param id      the ID of the listing to update
+   * @param request the updated listing data
+   * @return the updated listing
+   * @throws NotFoundException if no listing with the given ID exists
+   */
+  public ListingsResponse update(Long id, ListingsRequest request) {
+    logger.info("Updating listing with ID: {}", id);
+    Listings existing = listingsRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "Listing with ID " + id + " not found"));
+    applyRequest(existing, request);
+    Listings saved = listingsRepository.save(existing);
+    logger.info("Updated listing with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Deletes a listing by its ID.
+   *
+   * @param id the ID of the listing to delete
+   * @throws NotFoundException if no listing with the given ID exists
+   */
+  public void deleteById(Long id) {
+    logger.info("Deleting listing with ID: {}", id);
+    if (!listingsRepository.existsById(id)) {
+      throw new NotFoundException("Listing with ID " + id + " not found");
+    }
+    listingsRepository.deleteById(id);
+    logger.info("Deleted listing with ID: {}", id);
+  }
+
+  /**
+   * Applies the fields from a request DTO to a listing entity.
+   *
+   * @param entity  the entity to update
+   * @param request the request data
+   */
+  private void applyRequest(Listings entity, ListingsRequest request) {
+    CarModels carModel = carModelsRepository.findById(request.carModelId())
+        .orElseThrow(() -> new NotFoundException(
+            "Car model with ID " + request.carModelId() + " not found"));
+    Dealers dealer = dealersRepository.findById(request.dealerId())
+        .orElseThrow(() -> new NotFoundException(
+            "Dealer with ID " + request.dealerId() + " not found"));
+
+    entity.setCarModel(carModel);
+    entity.setDealer(dealer);
+    entity.setPlateNumber(request.plateNumber());
+    entity.setPrice(request.price());
+    entity.setAvailability(request.availability() != null ? request.availability() : Listings.Availability.AVAILABLE);
+    entity.setAvailableFrom(request.availableFrom());
+    entity.setVisible(request.visible() != null ? request.visible() : true);
+    entity.setColor(request.color());
+    entity.setCondition(request.condition());
+    entity.setMileage(request.mileage());
+    entity.setImageUrl(request.imageUrl());
+    entity.setSourceUrl(request.sourceUrl());
+  }
+
+  /**
+   * Converts a {@link Listings} entity to a {@link ListingsResponse} DTO.
+   *
+   * @param entity the entity to convert
+   * @return the response DTO
+   */
+  private ListingsResponse toResponse(Listings entity) {
+    CarModels cm = entity.getCarModel();
+    List<ExtraFeaturesResponse> extraFeatures = cm.getExtraFeatures() == null
+        ? List.of()
+        : cm.getExtraFeatures().stream()
+            .map(ef -> new ExtraFeaturesResponse(ef.getId(), ef.getName(), ef.getDescription()))
+            .toList();
+
+    CarModelsResponse carModelResponse = new CarModelsResponse(
+        cm.getId(), cm.getBrand(), cm.getModelName(), cm.getCarType(),
+        cm.getProductionYear(), cm.getPassengers(), cm.getTransmission(),
+        cm.getEnergySource(), cm.getEngine(), cm.getBatteryCapacityKwh(),
+        cm.getRangeKm(), cm.getRangeStandard(), cm.getTopSpeedKmh(),
+        cm.getAcceleration(), extraFeatures);
+
+    Dealers d = entity.getDealer();
+    DealersResponse dealerResponse = new DealersResponse(
+        d.getId(), d.getEmail(), d.getPhoneNumber(),
+        d.getRole(), d.getCreatedAt(), d.getCompanyName());
+
+    return new ListingsResponse(
+        entity.getId(), carModelResponse, dealerResponse,
+        entity.getPlateNumber(), entity.getPrice(), entity.getAvailability(),
+        entity.getAvailableFrom(), entity.isVisible(), entity.getColor(),
+        entity.getCondition(), entity.getMileage(), entity.getImageUrl(),
+        entity.getSourceUrl());
+  }
+}

--- a/src/main/java/no/ntnu/service/OrdersService.java
+++ b/src/main/java/no/ntnu/service/OrdersService.java
@@ -1,0 +1,252 @@
+package no.ntnu.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import no.ntnu.dto.carmodels.CarModelsResponse;
+import no.ntnu.dto.dealers.DealersResponse;
+import no.ntnu.dto.extrafeatures.ExtraFeaturesResponse;
+import no.ntnu.dto.listings.ListingsResponse;
+import no.ntnu.dto.orders.OrdersRequest;
+import no.ntnu.dto.orders.OrdersResponse;
+import no.ntnu.dto.users.UsersResponse;
+import no.ntnu.entity.CarModels;
+import no.ntnu.entity.Dealers;
+import no.ntnu.entity.Listings;
+import no.ntnu.entity.Orders;
+import no.ntnu.entity.Users;
+import no.ntnu.exception.NotFoundException;
+import no.ntnu.repository.DealersRepository;
+import no.ntnu.repository.ListingsRepository;
+import no.ntnu.repository.OrdersRepository;
+import no.ntnu.repository.UsersRepository;
+
+/**
+ * Service for managing {@link Orders} entities.
+ */
+@Service
+public class OrdersService {
+  private static final Logger logger = LoggerFactory.getLogger(OrdersService.class);
+
+  private final OrdersRepository ordersRepository;
+  private final UsersRepository usersRepository;
+  private final ListingsRepository listingsRepository;
+  private final DealersRepository dealersRepository;
+
+  public OrdersService(OrdersRepository ordersRepository,
+      UsersRepository usersRepository,
+      ListingsRepository listingsRepository,
+      DealersRepository dealersRepository) {
+    this.ordersRepository = ordersRepository;
+    this.usersRepository = usersRepository;
+    this.listingsRepository = listingsRepository;
+    this.dealersRepository = dealersRepository;
+  }
+
+  /**
+   * Retrieves all orders.
+   *
+   * @return a list of all orders
+   */
+  public List<OrdersResponse> getAll() {
+    logger.debug("Retrieving all orders");
+    return ordersRepository.findAll().stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Retrieves an order by its ID.
+   *
+   * @param id the ID of the order
+   * @return the order
+   * @throws NotFoundException if no order with the given ID exists
+   */
+  public OrdersResponse getById(Long id) {
+    logger.debug("Retrieving order with ID: {}", id);
+    return ordersRepository.findById(id)
+        .map(this::toResponse)
+        .orElseThrow(() -> new NotFoundException(
+            "Order with ID " + id + " not found"));
+  }
+
+  /**
+   * Retrieves all orders for a given buyer.
+   *
+   * @param userId the ID of the buyer
+   * @return a list of orders for the buyer
+   * @throws NotFoundException if no user with the given ID exists
+   */
+  public List<OrdersResponse> getByUserId(Long userId) {
+    logger.debug("Retrieving orders for user with ID: {}", userId);
+    if (!usersRepository.existsById(userId)) {
+      throw new NotFoundException("User with ID " + userId + " not found");
+    }
+    return ordersRepository.findByBuyerId(userId).stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Retrieves all orders for a given listing.
+   *
+   * @param listingId the ID of the listing
+   * @return a list of orders for the listing
+   * @throws NotFoundException if no listing with the given ID exists
+   */
+  public List<OrdersResponse> getByListingId(Long listingId) {
+    logger.debug("Retrieving orders for listing with ID: {}", listingId);
+    if (!listingsRepository.existsById(listingId)) {
+      throw new NotFoundException("Listing with ID " + listingId + " not found");
+    }
+    return ordersRepository.findByListingId(listingId).stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Creates a new order.
+   *
+   * @param request the order data
+   * @return the created order
+   */
+  public OrdersResponse create(OrdersRequest request) {
+    logger.info("Creating order for buyer {} on listing {}", request.buyerId(), request.listingId());
+    Orders entity = new Orders();
+    applyRequest(entity, request);
+    Orders saved = ordersRepository.save(entity);
+    logger.info("Created order with ID: {}", saved.getId());
+    return toResponse(saved);
+  }
+
+  /**
+   * Updates the status of an existing order.
+   *
+   * @param id     the ID of the order
+   * @param status the new status
+   * @return the updated order
+   * @throws NotFoundException if no order with the given ID exists
+   */
+  public OrdersResponse updateStatus(Long id, Orders.Status status) {
+    logger.info("Updating status of order {} to {}", id, status);
+    Orders existing = ordersRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "Order with ID " + id + " not found"));
+    existing.setStatus(status);
+    Orders saved = ordersRepository.save(existing);
+    logger.info("Updated status of order {} to {}", id, status);
+    return toResponse(saved);
+  }
+
+  /**
+   * Retrieves all orders for a given dealer.
+   *
+   * @param dealerId the ID of the dealer
+   * @return a list of orders for the dealer
+   */
+  public List<OrdersResponse> getByDealerId(Long dealerId) {
+    logger.debug("Retrieving orders for dealer with ID: {}", dealerId);
+    if (!dealersRepository.existsById(dealerId)) {
+      throw new NotFoundException("Dealer with ID " + dealerId + " not found");
+    }
+    return ordersRepository.findByListingDealerId(dealerId).stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  /**
+   * Soft-deletes an order by its ID.
+   *
+   * @param id the ID of the order to delete
+   * @throws NotFoundException if no order with the given ID exists
+   */
+  public void deleteById(Long id) {
+    logger.info("Deleting order with ID: {}", id);
+    Orders existing = ordersRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(
+            "Order with ID " + id + " not found"));
+    existing.setDeleted(true);
+    ordersRepository.save(existing);
+    logger.info("Deleted order with ID: {}", id);
+  }
+
+  /**
+   * Applies the fields from a request DTO to an order entity.
+   *
+   * @param entity  the entity to update
+   * @param request the request data
+   */
+  private void applyRequest(Orders entity, OrdersRequest request) {
+    Users buyer = usersRepository.findById(request.buyerId())
+        .orElseThrow(() -> new NotFoundException(
+            "User with ID " + request.buyerId() + " not found"));
+    Listings listing = listingsRepository.findById(request.listingId())
+        .orElseThrow(() -> new NotFoundException(
+            "Listing with ID " + request.listingId() + " not found"));
+    entity.setBuyer(buyer);
+    entity.setListing(listing);
+    entity.setPurchasePrice(listing.getPrice());
+  }
+
+  /**
+   * Converts an {@link Orders} entity to an {@link OrdersResponse} DTO.
+   *
+   * @param entity the entity to convert
+   * @return the response DTO
+   */
+  private OrdersResponse toResponse(Orders entity) {
+    return new OrdersResponse(
+        entity.getId(),
+        toUsersResponse(entity.getBuyer()),
+        toListingsResponse(entity.getListing()),
+        entity.getPurchasePrice(),
+        entity.getOrderedAt(),
+        entity.getStatus());
+  }
+
+  private UsersResponse toUsersResponse(Users user) {
+    Set<Long> favoriteListingIds = user.getFavoriteListings() == null
+        ? Set.of()
+        : user.getFavoriteListings().stream()
+            .map(Listings::getId)
+            .collect(Collectors.toSet());
+
+    return new UsersResponse(
+        user.getId(), user.getEmail(), user.getPhoneNumber(),
+        user.getRole(), user.getCreatedAt(), user.getFirstName(),
+        user.getLastName(), favoriteListingIds);
+  }
+
+  private ListingsResponse toListingsResponse(Listings listing) {
+    CarModels cm = listing.getCarModel();
+    List<ExtraFeaturesResponse> extraFeatures = cm.getExtraFeatures() == null
+        ? List.of()
+        : cm.getExtraFeatures().stream()
+            .map(ef -> new ExtraFeaturesResponse(ef.getId(), ef.getName(), ef.getDescription()))
+            .toList();
+
+    CarModelsResponse carModelResponse = new CarModelsResponse(
+        cm.getId(), cm.getBrand(), cm.getModelName(), cm.getCarType(),
+        cm.getProductionYear(), cm.getPassengers(), cm.getTransmission(),
+        cm.getEnergySource(), cm.getEngine(), cm.getBatteryCapacityKwh(),
+        cm.getRangeKm(), cm.getRangeStandard(), cm.getTopSpeedKmh(),
+        cm.getAcceleration(), extraFeatures);
+
+    Dealers d = listing.getDealer();
+    DealersResponse dealerResponse = new DealersResponse(
+        d.getId(), d.getEmail(), d.getPhoneNumber(),
+        d.getRole(), d.getCreatedAt(), d.getCompanyName());
+
+    return new ListingsResponse(
+        listing.getId(), carModelResponse, dealerResponse,
+        listing.getPlateNumber(), listing.getPrice(), listing.getAvailability(),
+        listing.getAvailableFrom(), listing.isVisible(), listing.getColor(),
+        listing.getCondition(), listing.getMileage(), listing.getImageUrl(),
+        listing.getSourceUrl());
+  }
+}


### PR DESCRIPTION
  ## Summary
  - Full CRUD REST API for Listings and Orders entities
  - DTOs with validation and Swagger documentation
  - Orders support soft delete

  ## Endpoints

  ### Listings (`/api/listings`)
  - `GET /` — list all
  - `GET /{id}` — get by ID
  - `GET /dealer/{dealerId}` — get by dealer
  - `POST /` — create
  - `PUT /{id}` — update
  - `DELETE /{id}` — delete

  ### Orders (`/api/orders`)
  - `GET /` — list all
  - `GET /{id}` — get by ID
  - `GET /user/{userId}` — get by buyer
  - `GET /listing/{listingId}` — get by listing
  - `GET /dealer/{dealerId}` — get by dealer
  - `POST /` — create
  - `PATCH /{id}/status` — update status
  - `DELETE /{id}` — soft delete

---

  Closes #14, #15, #26